### PR TITLE
Adds ability to use custom fonts in the switch

### DIFF
--- a/LLRoundSwitch/LLRoundSwitch.h
+++ b/LLRoundSwitch/LLRoundSwitch.h
@@ -35,6 +35,7 @@
 @property (nonatomic, getter=isOn) BOOL on;				// default: NO
 @property (nonatomic, copy) NSString *onText;			// default: 'ON' - not automatically localized!
 @property (nonatomic, copy) NSString *offText;			// default: 'OFF' - not automatically localized!
+@property (nonatomic, copy) NSString *fontFamiliy;
 
 - (void)setOn:(BOOL)newOn animated:(BOOL)animated;
 

--- a/LLRoundSwitch/LLRoundSwitch.h
+++ b/LLRoundSwitch/LLRoundSwitch.h
@@ -35,7 +35,7 @@
 @property (nonatomic, getter=isOn) BOOL on;				// default: NO
 @property (nonatomic, copy) NSString *onText;			// default: 'ON' - not automatically localized!
 @property (nonatomic, copy) NSString *offText;			// default: 'OFF' - not automatically localized!
-@property (nonatomic, copy) UIFont *font;               // default: boldSystemFont, size is calculated automatically
+@property (nonatomic, retain) UIFont *font;               // default: boldSystemFont, size is calculated automatically
 
 - (void)setOn:(BOOL)newOn animated:(BOOL)animated;
 

--- a/LLRoundSwitch/LLRoundSwitch.h
+++ b/LLRoundSwitch/LLRoundSwitch.h
@@ -35,7 +35,7 @@
 @property (nonatomic, getter=isOn) BOOL on;				// default: NO
 @property (nonatomic, copy) NSString *onText;			// default: 'ON' - not automatically localized!
 @property (nonatomic, copy) NSString *offText;			// default: 'OFF' - not automatically localized!
-@property (nonatomic, copy) NSString *fontFamiliy;
+@property (nonatomic, copy) UIFont *font;               // default: boldSystemFont, size is calculated automatically
 
 - (void)setOn:(BOOL)newOn animated:(BOOL)animated;
 

--- a/LLRoundSwitch/LLRoundSwitch.m
+++ b/LLRoundSwitch/LLRoundSwitch.m
@@ -132,6 +132,11 @@
 	self.frame = newFrame;
 }
 
+- (CGSize)sizeThatFits:(CGSize)size {
+    // shouldn't this be calculated? uses the values from sizeToFit
+    return CGSizeMake(77.0f, 27.0f);
+}
+
 - (void)useLayerMasking
 {
 	// turn of the manual clipping (done in toggleLayer's drawInContext:)

--- a/LLRoundSwitch/LLRoundSwitch.m
+++ b/LLRoundSwitch/LLRoundSwitch.m
@@ -396,4 +396,28 @@
     toggleLayer.fontFamiliy = _fontFamiliy;
     [toggleLayer setNeedsDisplay];
 }
+
+
+#pragma mark - accessibility
+
+
+- (BOOL)isAccessibilityElement {
+    return YES;
+}
+
+- (NSString *)accessibilityLabel {
+    return NSLocalizedString(@"On off switch", nil);
+}
+
+- (UIAccessibilityTraits)accessibilityTraits {
+    return UIAccessibilityTraitButton;
+}
+
+- (NSString *)accessibilityHint {
+    if (self.on) {
+        return NSLocalizedString(@"Change switch to %@", self.offText);
+    } else {
+        return NSLocalizedString(@"Change switch to %@", self.onText);
+    }
+}
 @end

--- a/LLRoundSwitch/LLRoundSwitch.m
+++ b/LLRoundSwitch/LLRoundSwitch.m
@@ -391,9 +391,9 @@
 	}
 }
 
-- (void)setFontFamiliy:(NSString *)fontFamiliy {
-    _fontFamiliy = [fontFamiliy copy];
-    toggleLayer.fontFamiliy = _fontFamiliy;
+- (void)setFont:(UIFont *)font {
+    _font = [font copy];
+    toggleLayer.font = _font;
     [toggleLayer setNeedsDisplay];
 }
 

--- a/LLRoundSwitch/LLRoundSwitch.m
+++ b/LLRoundSwitch/LLRoundSwitch.m
@@ -386,4 +386,9 @@
 	}
 }
 
+- (void)setFontFamiliy:(NSString *)fontFamiliy {
+    _fontFamiliy = [fontFamiliy copy];
+    toggleLayer.fontFamiliy = _fontFamiliy;
+    [toggleLayer setNeedsDisplay];
+}
 @end

--- a/LLRoundSwitch/LLRoundSwitch.m
+++ b/LLRoundSwitch/LLRoundSwitch.m
@@ -392,7 +392,7 @@
 }
 
 - (void)setFont:(UIFont *)font {
-    _font = [font copy];
+    _font = font;
     toggleLayer.font = _font;
     [toggleLayer setNeedsDisplay];
 }

--- a/LLRoundSwitch/LLRoundSwitchToggleLayer.h
+++ b/LLRoundSwitch/LLRoundSwitchToggleLayer.h
@@ -16,7 +16,7 @@
 @property (nonatomic, retain) UIColor *onTintColor;
 @property (nonatomic, retain) NSString *onString;
 @property (nonatomic, retain) NSString *offString;
-@property (nonatomic, retain) NSString *fontFamiliy;
+@property (nonatomic, retain) UIFont *font;
 
 @property (nonatomic) BOOL drawOnTint;
 @property (nonatomic) BOOL clip;

--- a/LLRoundSwitch/LLRoundSwitchToggleLayer.h
+++ b/LLRoundSwitch/LLRoundSwitchToggleLayer.h
@@ -16,6 +16,8 @@
 @property (nonatomic, retain) UIColor *onTintColor;
 @property (nonatomic, retain) NSString *onString;
 @property (nonatomic, retain) NSString *offString;
+@property (nonatomic, retain) NSString *fontFamiliy;
+
 @property (nonatomic) BOOL drawOnTint;
 @property (nonatomic) BOOL clip;
 

--- a/LLRoundSwitch/LLRoundSwitchToggleLayer.m
+++ b/LLRoundSwitch/LLRoundSwitchToggleLayer.m
@@ -66,7 +66,14 @@
     CGContextSetShadowWithColor(context, CGSizeMake(0,0), 0, NULL);
     
     // strings
-    UIFont *font = [UIFont boldSystemFontOfSize:ceilf(self.bounds.size.height * .6)];
+    UIFont *font = nil;
+    CGFloat fontSize = ceilf(self.bounds.size.height * .6);
+    
+    if (self.fontFamiliy) {
+        font = [UIFont fontWithName:self.fontFamiliy size:fontSize];
+    } else {
+        font = [UIFont boldSystemFontOfSize:fontSize];
+    }
     CGFloat textSpaceWidth = (self.bounds.size.width / 2) - (knobRadius / 2);
     
     UIGraphicsPushContext(context);

--- a/LLRoundSwitch/LLRoundSwitchToggleLayer.m
+++ b/LLRoundSwitch/LLRoundSwitchToggleLayer.m
@@ -25,6 +25,7 @@
         self.onString = anOnString;
         self.offString = anOffString;
         self.onTintColor = anOnTintColor;
+        self.font = [UIFont boldSystemFontOfSize:10.0f];
     }
     return self;
 }
@@ -66,14 +67,8 @@
     CGContextSetShadowWithColor(context, CGSizeMake(0,0), 0, NULL);
     
     // strings
-    UIFont *font = nil;
-    CGFloat fontSize = ceilf(self.bounds.size.height * .6);
+    UIFont *font = [self.font fontWithSize:ceilf(self.bounds.size.height * .6)];
     
-    if (self.fontFamiliy) {
-        font = [UIFont fontWithName:self.fontFamiliy size:fontSize];
-    } else {
-        font = [UIFont boldSystemFontOfSize:fontSize];
-    }
     CGFloat textSpaceWidth = (self.bounds.size.width / 2) - (knobRadius / 2);
     
     UIGraphicsPushContext(context);
@@ -103,4 +98,8 @@
 	UIGraphicsPopContext();
 }
 
+- (void)setFont:(UIFont *)font {
+    _font = font;
+    [self setNeedsDisplay];
+}
 @end

--- a/LLRoundSwitchDemo/LLRoundSwitchDemo/LLRoundSwitchDemoViewController.m
+++ b/LLRoundSwitchDemo/LLRoundSwitchDemo/LLRoundSwitchDemoViewController.m
@@ -36,6 +36,7 @@
     // How about a little red and a turn-on for switch2
     switch2.onTintColor = [UIColor redColor];
     switch2.on = YES;
+    switch2.fontFamiliy = @"Futura";
     
     // switch3 wants to be black and on
     switch3.onTintColor = [UIColor blackColor];


### PR DESCRIPTION
Adds a fontFamiliy property to both LLRoundSwitch & LLRoundSwitchToggle which when set is used as the font for the switch. Doesn't use a font object because the size of the font is calculated at runtime so a fontFamily a string is sufficient.
